### PR TITLE
Fix selectors (missing dot)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,25 +3,25 @@ module.exports = function (variants) {
     addUtilities(
       {
         // List Style Type
-        'list-disc': { listStyleType: 'disc' },
-        'list-circle': { listStyleType: 'circle' },
-        'list-square': { listStyleType: 'square' },
-        'list-decimal': { listStyleType: 'decimal' },
-        'list-decimal-leading-zero': { listStyleType: 'decimal-leading-zero' },
-        'list-lower-roman': { listStyleType: 'lower-roman' },
-        'list-upper-roman': { listStyleType: 'upper-roman' },
-        'list-lower-greek': { listStyleType: 'lower-greek' },
-        'list-lower-latin': { listStyleType: 'lower-latin' },
-        'list-upper-latin': { listStyleType: 'upper-latin' },
-        'list-armenian': { listStyleType: 'armenian' },
-        'list-georgian': { listStyleType: 'georgian' },
-        'list-lower-alpha': { listStyleType: 'lower-alpha' },
-        'list-upper-alpha': { listStyleType: 'upper-alpha' },
-        'list-none': { listStyleType: 'none' },
+        '.list-disc': { listStyleType: 'disc' },
+        '.list-circle': { listStyleType: 'circle' },
+        '.list-square': { listStyleType: 'square' },
+        '.list-decimal': { listStyleType: 'decimal' },
+        '.list-decimal-leading-zero': { listStyleType: 'decimal-leading-zero' },
+        '.list-lower-roman': { listStyleType: 'lower-roman' },
+        '.list-upper-roman': { listStyleType: 'upper-roman' },
+        '.list-lower-greek': { listStyleType: 'lower-greek' },
+        '.list-lower-latin': { listStyleType: 'lower-latin' },
+        '.list-upper-latin': { listStyleType: 'upper-latin' },
+        '.list-armenian': { listStyleType: 'armenian' },
+        '.list-georgian': { listStyleType: 'georgian' },
+        '.list-lower-alpha': { listStyleType: 'lower-alpha' },
+        '.list-upper-alpha': { listStyleType: 'upper-alpha' },
+        '.list-none': { listStyleType: 'none' },
 
         // List Style Position
-        'list-inside': { listStylePosition: 'inside' },
-        'list-outside': { listStylePosition: 'outside' },
+        '.list-inside': { listStylePosition: 'inside' },
+        '.list-outside': { listStylePosition: 'outside' },
       },
       variants
     )


### PR DESCRIPTION
Not sure if this plugin worked for you as-is, but I got the following error when I passed `['responsive']`:

```
Variant cannot be generated because selector contains no classes.
```

So then I passed `[]` instead (no variants), and I noticed the generated CSS was missing dots in front of the selectors:

```
list-disc {
  list-style-type: disc;
}

list-circle {
  list-style-type: circle;
}

list-square {
  list-style-type: square;
}
```
etc.

This PR fixes it.